### PR TITLE
Fix warnings and remove ament_lint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,14 +78,6 @@ install_scripts(
 
 if(BUILD_TESTING)
     find_package(ament_cmake_pytest REQUIRED)
-    find_package(ament_lint_auto REQUIRED)
-    # the following line skips the linter which checks for copyrights
-    # uncomment the line when a copyright and license is not present in all source files
-    #set(ament_cmake_copyright_FOUND TRUE)
-    # the following line skips cpplint (only works in a git repo)
-    # uncomment the line when this package is not in a git repo
-    #set(ament_cmake_cpplint_FOUND TRUE)
-    ament_lint_auto_find_test_dependencies()
 
     # Python tests
     ament_add_pytest_test(test_solo12_config tests/test_solo12_config.py)

--- a/demos/demo_solo12_hold.cpp
+++ b/demos/demo_solo12_hold.cpp
@@ -3,8 +3,8 @@
  * \brief Demo using Solo12 that holds all joints at their current positions.
  * \copyright Copyright (c) 2022, Max Planck Gesellschaft.
  */
-#include <string>
 #include <memory>
+#include <string>
 
 #include <cli_utils/program_options.hpp>
 

--- a/demos/demo_solo12_hold.cpp
+++ b/demos/demo_solo12_hold.cpp
@@ -3,11 +3,14 @@
  * \brief Demo using Solo12 that holds all joints at their current positions.
  * \copyright Copyright (c) 2022, Max Planck Gesellschaft.
  */
+#include <string>
+#include <memory>
+
 #include <cli_utils/program_options.hpp>
 
 #include <robot_interfaces_solo/solo12_driver.hpp>
 
-using namespace robot_interfaces_solo;
+namespace ris = robot_interfaces_solo;
 
 // Class to get console arguments
 class Args : public cli_utils::ProgramOptions
@@ -57,24 +60,24 @@ int main(int argc, char *argv[])
     }
 
     // load the driver configuration from a YAML file
-    Solo12Config config = Solo12Config::from_file(args.config_file);
+    ris::Solo12Config config = ris::Solo12Config::from_file(args.config_file);
 
     // create a robot data instance, robot backend and frontend.
-    auto data = std::make_shared<Solo12SingleProcessData>();
-    Solo12Backend::Ptr backend = create_solo12_backend(data, config);
-    Solo12Frontend frontend(data);
+    auto data = std::make_shared<ris::Solo12SingleProcessData>();
+    ris::Solo12Backend::Ptr backend = create_solo12_backend(data, config);
+    ris::Solo12Frontend frontend(data);
 
     // initialise the robot (this also runs the homing)
     backend->initialize();
 
     // start with a zero-torque action (we need to send an initial action first,
     // before we can access the observation)
-    auto t = frontend.append_desired_action(Solo12Action::Zero());
-    Solo12Observation obs = frontend.get_observation(t);
+    auto t = frontend.append_desired_action(ris::Solo12Action::Zero());
+    ris::Solo12Observation obs = frontend.get_observation(t);
 
     // construct a simple position control action, using the current position
     // from the observation as target position.
-    Solo12Action action;
+    ris::Solo12Action action;
     action.joint_position_gains.fill(args.kp);
     action.joint_velocity_gains.fill(args.kd);
     action.joint_positions = obs.joint_positions;

--- a/include/robot_interfaces_solo/solo12_action.hpp
+++ b/include/robot_interfaces_solo/solo12_action.hpp
@@ -5,8 +5,8 @@
  */
 #pragma once
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include <Eigen/Eigen>
 #include <cereal/cereal.hpp>

--- a/include/robot_interfaces_solo/solo12_action.hpp
+++ b/include/robot_interfaces_solo/solo12_action.hpp
@@ -5,6 +5,9 @@
  */
 #pragma once
 
+#include <vector>
+#include <string>
+
 #include <Eigen/Eigen>
 #include <cereal/cereal.hpp>
 #include <serialization_utils/cereal_eigen.hpp>

--- a/include/robot_interfaces_solo/solo12_driver.hpp
+++ b/include/robot_interfaces_solo/solo12_driver.hpp
@@ -6,6 +6,9 @@
 #pragma once
 
 #include <filesystem>
+#include <limits>
+#include <memory>
+#include <string>
 
 #include <spdlog/spdlog.h>
 
@@ -91,7 +94,7 @@ class Solo12Driver
 public:
     inline static const std::string LOGGER_NAME = "Solo12Driver";
 
-    Solo12Driver(const Solo12Config &config);
+    explicit Solo12Driver(const Solo12Config &config);
 
     // RobotDriver methods
     void initialize() override;
@@ -115,7 +118,7 @@ class FakeSolo12Driver
 public:
     inline static const std::string LOGGER_NAME = "FakeSolo12Driver";
 
-    FakeSolo12Driver(const Solo12Config &config);
+    explicit FakeSolo12Driver(const Solo12Config &config);
 
     // RobotDriver methods
     void initialize() override;

--- a/include/robot_interfaces_solo/solo12_driver.hpp
+++ b/include/robot_interfaces_solo/solo12_driver.hpp
@@ -111,7 +111,8 @@ private:
     bool is_initialized_ = false;
 };
 
-//! Fake driver for testing (ignores actions and returns some artificial observations).
+//! Fake driver for testing (ignores actions and returns some artificial
+//! observations).
 class FakeSolo12Driver
     : public robot_interfaces::RobotDriver<Solo12Action, Solo12Observation>
 {

--- a/include/robot_interfaces_solo/solo12_observation.hpp
+++ b/include/robot_interfaces_solo/solo12_observation.hpp
@@ -6,6 +6,8 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
+#include <vector>
 
 #include <Eigen/Eigen>
 #include <cereal/cereal.hpp>

--- a/package.xml
+++ b/package.xml
@@ -17,9 +17,6 @@
   <depend>solo</depend>
   <depend>real_time_tools</depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/solo12_driver.cpp
+++ b/src/solo12_driver.cpp
@@ -5,8 +5,8 @@
 #include <memory>
 #include <string>
 
-#include <spdlog/sinks/stdout_color_sinks.h>
 #include <fmt/format.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
 #include <yaml-cpp/yaml.h>
 #include <boost/range/adaptor/indexed.hpp>
 

--- a/src/solo12_driver.cpp
+++ b/src/solo12_driver.cpp
@@ -1,6 +1,9 @@
 #include <robot_interfaces_solo/solo12_driver.hpp>
 
 #include <cmath>
+#include <limits>
+#include <memory>
+#include <string>
 
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <fmt/format.h>

--- a/srcpy/solo12.cpp
+++ b/srcpy/solo12.cpp
@@ -3,6 +3,9 @@
  * \brief Python bindings for Solo12
  * \copyright Copyright (c) 2022, Max Planck Gesellschaft.
  */
+#include <limits>
+#include <memory>
+
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -11,7 +14,7 @@
 #include <robot_interfaces/pybind_helper.hpp>
 #include <robot_interfaces_solo/solo12_driver.hpp>
 
-using namespace robot_interfaces_solo;
+namespace ris = robot_interfaces_solo;
 
 PYBIND11_MODULE(solo12, m)
 {
@@ -23,32 +26,33 @@ PYBIND11_MODULE(solo12, m)
     // import robot_interfaces to provide bindings for Status
     pybind11::module::import("robot_interfaces");
 
-    robot_interfaces::create_interface_python_bindings<Solo12Action,
-                                                       Solo12Observation>(m);
+    robot_interfaces::create_interface_python_bindings<ris::Solo12Action,
+                                                       ris::Solo12Observation>(
+        m);
 
-    pybind11::class_<Solo12Action>(m, "Action", "Action for Solo12")
+    pybind11::class_<ris::Solo12Action>(m, "Action", "Action for Solo12")
         .def(pybind11::init<>())
         .def_readwrite("joint_torques",
-                       &Solo12Action::joint_torques,
+                       &ris::Solo12Action::joint_torques,
                        "List of desired torques, one per joint.")
         .def_readwrite("joint_positions",
-                       &Solo12Action::joint_positions,
+                       &ris::Solo12Action::joint_positions,
                        "Desired joint positions of the P controller running on "
                        "the card.  For this to have an effect "
                        ":attr:`joint_position_gains` needs to be set as well.")
         .def_readwrite("joint_velocities",
-                       &Solo12Action::joint_velocities,
+                       &ris::Solo12Action::joint_velocities,
                        "desired joint velocity of the D controller running on "
                        "the card.  For this to have an effect, "
                        ":attr:`joint_velocity_gains` needs to be set as well.")
         .def_readwrite("joint_position_gains",
-                       &Solo12Action::joint_position_gains,
+                       &ris::Solo12Action::joint_position_gains,
                        "P-gains for the on-board controller, one per joint.")
         .def_readwrite("joint_velocity_gains",
-                       &Solo12Action::joint_velocity_gains,
+                       &ris::Solo12Action::joint_velocity_gains,
                        "D-gains for the on-barod controller, one per joint.")
         .def(pybind11::pickle(
-            [](const Solo12Action &a) {  // __getstate__
+            [](const ris::Solo12Action &a) {  // __getstate__
                 // Return a tuple that fully encodes the state of the object
                 return pybind11::make_tuple(a.joint_torques,
                                             a.joint_positions,
@@ -63,69 +67,73 @@ PYBIND11_MODULE(solo12, m)
                 }
 
                 // Create a new C++ instance
-                Solo12Action action;
-                action.joint_torques = t[0].cast<Vector12d>();
-                action.joint_positions = t[1].cast<Vector12d>();
-                action.joint_velocities = t[2].cast<Vector12d>();
-                action.joint_position_gains = t[3].cast<Vector12d>();
-                action.joint_velocity_gains = t[4].cast<Vector12d>();
+                ris::Solo12Action action;
+                action.joint_torques = t[0].cast<ris::Vector12d>();
+                action.joint_positions = t[1].cast<ris::Vector12d>();
+                action.joint_velocities = t[2].cast<ris::Vector12d>();
+                action.joint_position_gains = t[3].cast<ris::Vector12d>();
+                action.joint_velocity_gains = t[4].cast<ris::Vector12d>();
 
                 return action;
             }))
-        .def("Zero", &Solo12Action::Zero, "Create a zero-torque action");
+        .def("Zero", &ris::Solo12Action::Zero, "Create a zero-torque action");
 
-    pybind11::class_<Solo12Observation>(m, "Observation")
+    pybind11::class_<ris::Solo12Observation>(m, "Observation")
         .def(pybind11::init<>())
-        .def_readwrite("joint_positions", &Solo12Observation::joint_positions)
-        .def_readwrite("joint_velocities", &Solo12Observation::joint_velocities)
-        .def_readwrite("joint_torques", &Solo12Observation::joint_torques)
+        .def_readwrite("joint_positions",
+                       &ris::Solo12Observation::joint_positions)
+        .def_readwrite("joint_velocities",
+                       &ris::Solo12Observation::joint_velocities)
+        .def_readwrite("joint_torques", &ris::Solo12Observation::joint_torques)
         .def_readwrite("joint_target_torques",
-                       &Solo12Observation::joint_target_torques)
+                       &ris::Solo12Observation::joint_target_torques)
         .def_readwrite("joint_encoder_index",
-                       &Solo12Observation::joint_encoder_index)
-        .def_readwrite("slider_positions", &Solo12Observation::slider_positions)
+                       &ris::Solo12Observation::joint_encoder_index)
+        .def_readwrite("slider_positions",
+                       &ris::Solo12Observation::slider_positions)
         .def_readwrite("imu_accelerometer",
-                       &Solo12Observation::imu_accelerometer)
-        .def_readwrite("imu_gyroscope", &Solo12Observation::imu_gyroscope)
+                       &ris::Solo12Observation::imu_accelerometer)
+        .def_readwrite("imu_gyroscope", &ris::Solo12Observation::imu_gyroscope)
         .def_readwrite("imu_linear_acceleration",
-                       &Solo12Observation::imu_linear_acceleration)
-        .def_readwrite("imu_attitude", &Solo12Observation::imu_attitude)
+                       &ris::Solo12Observation::imu_linear_acceleration)
+        .def_readwrite("imu_attitude", &ris::Solo12Observation::imu_attitude)
         .def_readwrite("num_sent_command_packets",
-                       &Solo12Observation::num_sent_command_packets)
+                       &ris::Solo12Observation::num_sent_command_packets)
         .def_readwrite("num_lost_command_packets",
-                       &Solo12Observation::num_lost_command_packets)
+                       &ris::Solo12Observation::num_lost_command_packets)
         .def_readwrite("num_sent_sensor_packets",
-                       &Solo12Observation::num_sent_sensor_packets)
+                       &ris::Solo12Observation::num_sent_sensor_packets)
         .def_readwrite("num_lost_sensor_packets",
-                       &Solo12Observation::num_lost_sensor_packets);
+                       &ris::Solo12Observation::num_lost_sensor_packets);
 
-    pybind11::class_<Solo12Config, std::shared_ptr<Solo12Config>>(m, "Config")
+    pybind11::class_<ris::Solo12Config, std::shared_ptr<ris::Solo12Config>>(
+        m, "Config")
         .def(pybind11::init<>())
         .def_readwrite("network_interface",
-                       &Solo12Config::network_interface,
+                       &ris::Solo12Config::network_interface,
                        "Name of the network interface to which the robot is "
                        "connected (e.g. 'eth0')")
         .def_readwrite("slider_serial_port",
-                       &Solo12Config::slider_serial_port,
+                       &ris::Solo12Config::slider_serial_port,
                        "Name of the serial port to which the hardware slider "
                        "is connected. This can typically be left empty, in "
                        "which case the port is auto-detected.")
         .def_readwrite(
             "max_motor_current_A",
-            &Solo12Config::max_motor_current_A,
+            &ris::Solo12Config::max_motor_current_A,
             "Maximum current that can be applied to the motors (in Ampere).")
         .def_readwrite("home_offset_rad",
-                       &Solo12Config::home_offset_rad,
+                       &ris::Solo12Config::home_offset_rad,
                        "Offset between home position (=encoder index) and zero "
                        "position.\n\nAngles (in radian) between the encoder "
                        "index and the zero position of each joint.")
         .def("from_file",
-             &Solo12Config::from_file,
+             &ris::Solo12Config::from_file,
              "Load configuration from a YAML file (using default values for "
              "parameters missing in the file).");
 
     m.def("create_backend",
-          &create_solo12_backend,
+          &ris::create_solo12_backend,
           pybind11::arg("robot_data"),
           pybind11::arg("driver_config"),
           pybind11::arg("first_action_timeout") =
@@ -133,7 +141,7 @@ PYBIND11_MODULE(solo12, m)
           pybind11::arg("max_number_of_actions") = 0);
 
     m.def("create_fake_backend",
-          &create_fake_solo12_backend,
+          &ris::create_fake_solo12_backend,
           pybind11::arg("robot_data"),
           pybind11::arg("driver_config"),
           pybind11::arg("first_action_timeout") =


### PR DESCRIPTION
## Description

- Fix some cpplint warnings
- Remove ament_lint from tests (most of the checks where not fully applicable to our setup (e.g. due to
different style guide used) and made the tests fail).


## How I Tested

By running `colcon test`.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
